### PR TITLE
Included code to determine eq temps

### DIFF
--- a/materials/material.py
+++ b/materials/material.py
@@ -48,6 +48,7 @@ class Material:
             self.name = mat.get_name()
             self.density = mat.get_density()
             self.max_temp = mat.get_max_temp()
+            self.abs_coeff = mat.get_abs_coeff()
             self.n_list = mat.get_n_list()
             self.k_list = mat.get_k_list()
             self.n_equations = mat.get_n_equations()
@@ -56,6 +57,7 @@ class Material:
             self.name = name
             self.density = density
             self.max_temp = max_temp
+            self.abs_coeff = abs_coeff
             self.n_list = n_list
             self.k_list = k_list
             self.n_equations = None
@@ -76,6 +78,13 @@ class Material:
         self.max_temp = max_temp
         save_material(self)
 
+    def get_abs_coeff(self):
+        return self.abs_coeff
+
+    def set_abs_coeff(self, abs_coeff):
+        self.abs_coeff = abs_coeff
+        save_material(self)
+        
     def get_name(self):
         return self.name
 


### PR DESCRIPTION
Rewrote _find_absorptance() to determine the absorptance of a multilayer_sail depending on the abs_coeffs of the materials that compose it. Added functionality to include a wavelength to allow for finding absorptances at different wavelengths (not just the initial laser wavelength, as previously written)

Wrote _find_eq_temps_given_abs_coeff() which allows for the finding of sail equilibrium temperatures if the absorption coefficients of the materials that compose it are provided. Updated from previous version by using a Newton method to implicitly solve for equilibrium temperature instead of poorly time-optimised bisection method. Large changes made to work with material Objects.

Note: future use of find_eq_temps_given_abs_coeff() should be through a file which determines these equilibrium temperatures over a range of abs_coeffs for a single material. Current implementation is used for generality and allows for user manipulation for additional use where that may exist