### PR TITLE
Several fixes to thermal codes

### DIFF
--- a/materials/interpolator.py
+++ b/materials/interpolator.py
@@ -4,9 +4,11 @@ def interpolate_from_list(ls, wavelength):
         to 0. If the list provided is NoneType or empty, returns 0.
     """
 
-    if ls == None or len(ls) == 0:
+    if ls is None:
         return 0
-    
+    elif len(ls) == 0:
+        return 0
+
     # From materials, the given list will be in ascending order, so we can
     # use this to our advantage
 
@@ -18,7 +20,6 @@ def interpolate_from_list(ls, wavelength):
         # performing linear interpolation between points in the list using the
         # point-gradient formula
         for i, (wl, val) in enumerate(ls):
-            print(wl, val)
             if wavelength == wl:
                 value = val
                 # the first instance where the wavelength input is larger than a


### PR DESCRIPTION
- find_W() and find_diameter() functions appear to be currently broken and are commented out
- fixed find_absorptance and find_structure so that the default wavelength value is correctly set to self.wavelength (when either the user issues no argument, or passes None as an argument)
- spectral_power_flux method fixed by proper implementation of list.reverse() method
- find_eq_temps_given_abs_coeff renamed to find_eq_temp. Newton's method for finding roots is not appropriate at low sail temperatures and was replaced by Brent's method  which requires a bracketing interval. This interval is automatically determined by the code. Also updated units used in power_in_minus_power_out